### PR TITLE
Switch to use latest Rally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==================================
-Docker plugins for Rally Framework
-==================================
+===================================
+Docker plugins for xRally Framework
+===================================
 
 
 What is it?!

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
--e git+git://github.com/openstack/rally.git@0b06cd1bfb85b92a28c44d4113f770c0869ff2ac#egg=rally
+-e git+git://github.com/openstack/rally.git@5140b8092ad220f53eed525ba95e8600bb58505f#egg=rally
 docker

--- a/tox.ini
+++ b/tox.ini
@@ -15,13 +15,13 @@ whitelist_externals = find
                       make
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-install_command = pip install  -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt {packages}
+install_command = pip install {packages} 
 usedevelop = True
 commands =
   find . -type f -name "*.pyc" -delete
   python {toxinidir}/tests/ci/pytest_launcher.py tests/unit --posargs={posargs}
 distribute = false
-basepython = python3.5
+basepython = python2.7
 passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 
 [testenv:pep8]


### PR DESCRIPTION
The latest rally contains several imprortant fixes related to loading
plugins by entry-points and broken requirements.

To make xRally-docker plugins auto-discoverable, we need to switch to
latest merged patch in rally.

PS: after Rally 0.10.0 will be release, we will abandon switching
between commits and use tagged version