### PR TITLE
Change url of the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
     long_description=read_data("README.md"),
     long_description_content_type="text/markdown",
     author="Andrey Kurilin",
-    url="https://rally.readthedocs.io",
+    url="https://xrally.org/plugins/docker/overview",
     license="Apache License, Version 2.0",
     entry_points={
         "rally_plugins": [


### PR DESCRIPTION
In the process of migrating all documentation stuff to xrally.org from
old rally.readthedocs.io, the special page for Docker plugins was
created. Let's use it as a reference in the python package.