### PR TITLE
Fix cleanup for images

### DIFF
--- a/tests/unit/common/cleanup/test_resources.py
+++ b/tests/unit/common/cleanup/test_resources.py
@@ -68,7 +68,7 @@ class ResourceManagerTestCase(test.TestCase):
 
 class ImageTestCase(object):
     def test_name(self):
-        res = {"Tags": ["foo:bar", "xxx:yyy"]}
+        res = {"RepoTags": ["foo:bar", "xxx:yyy"]}
         self.assertEqual(
             ["bar", "yyy"],
             resources.Image(res, None).name())

--- a/xrally_docker/common/cleanup/resources.py
+++ b/xrally_docker/common/cleanup/resources.py
@@ -103,7 +103,7 @@ class ResourceManager(object):
 class Image(ResourceManager):
     def name(self):
         return [tag.split(":", 1)[1]
-                for tag in self.raw_resource["Tags"]]
+                for tag in self.raw_resource["RepoTags"]]
 
 
 @configure("network")


### PR DESCRIPTION
There is no "Tags" attribute in Image dict-object. "RepoTags" should be
used instead.

NOTE: we use image tags to identify images created by rally